### PR TITLE
Removed resizing and centering the raised window.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # gnome-shell-extension-raise-covered
 
+**FORK EDIT**: I removed the code that centers and resizes the window which is being held on top. This prevents windows from jumping around while preserving the purpose of this extension. Original readme follows.
+
+------------------------------------------------
+
 Automatically raises windows covered by maximized ones.
 
 # Screencast

--- a/extension.js
+++ b/extension.js
@@ -17,12 +17,12 @@ function windowIsNormal(win) {
   return win.window_type === Meta.WindowType.NORMAL;
 }
 
-function windowPlace(win) {
-  let {x, y, width, height} = win.get_work_area_current_monitor();
-  width -= 2 * (x += 0.3 * width);
-  height -= 2 * (y += 0.2 * height);
-  win.move_resize_frame(false, x, y, width, height);
-}
+//function windowPlace(win) {
+//  let {x, y, width, height} = win.get_work_area_current_monitor();
+//  width -= 2 * (x += 0.3 * width);
+//  height -= 2 * (y += 0.2 * height);
+//  win.move_resize_frame(false, x, y, width, height);
+//}
 
 function workspaceTopWindows(ws) {
   let tops = [];
@@ -53,8 +53,8 @@ function workspaceCheck(ws) {
     w.raise();
     let rect = w.get_frame_rect();
     let ints = tops.map(t => t.get_frame_rect().intersect(rect)[1]);
-    if (ints.some(int => int.area() > rect.area() * 0.5))
-      windowPlace(w);
+//    if (ints.some(int => int.area() > rect.area() * 0.5))
+//      windowPlace(w);
   }
 }
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
 {
   "name": "Raise Covered",
-  "uuid": "raisecovered@rliang.github.com",
+  "uuid": "raisecovered@stove-panini.github.com",
   "description": "Automatically raises windows covered by maximized ones.",
-  "url": "https://github.com/rliang/gnome-shell-extension-raise-covered",
+  "url": "https://github.com/stove-panini/gnome-shell-extension-raise-covered",
   "shell-version": ["3.14", "3.16", "3.18", "3.20", "3.22", "3.24"]
 }


### PR DESCRIPTION
In this change, I just removed the lines which center and resize a window that is automatically raised by this extension. The floating window will stay in place and simply refuse to be covered. I find this less visually distracting.